### PR TITLE
bugfix for should update project runtime info from processor by sendi…

### DIFF
--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -110,7 +110,7 @@ class Project(object):
         self.updatetime = project_info['updatetime']
 
         md5sum = utils.md5string(project_info['script'])
-        if (self.md5sum != md5sum or self.waiting_get_info) and self.active:
+        if self.md5sum != md5sum or self.waiting_get_info:
             self._send_on_get_info = True
             self.waiting_get_info = True
         self.md5sum = md5sum


### PR DESCRIPTION
### bugfix for should update project runtime info from processor by sending a _on_get_info when save script on webui

when edit crawling script and save, then change the project to running, the new crawl_config DO NOT take effect. 
the reason is: 
1. script changed and saved, at that time the project status is switching to CHECKING. the code `if (self.md5sum != md5sum or self.waiting_get_info) and self.active` in `update` function will evaluate to false because of `self.active`. And the following code is `self.md5sum = md5sum` which update the md5sum of script. 
2. when we switch the project to RUNNING, the condition above is also evaluated to false because ` self.md5sum != md5sum` is false, so there is no chance to update  project runtime info any more.